### PR TITLE
pdf形式対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "pgvector", "~> 0.3"
 gem "neighbor"
 gem "dotenv-rails"
+gem "pdf-reader", "~> 2.12"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     actioncable (8.0.3)
       actionpack (= 8.0.3)
       activesupport (= 8.0.3)
@@ -72,6 +73,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    afm (1.0.0)
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.3.1)
@@ -92,6 +94,7 @@ GEM
     erubi (1.13.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hashery (2.1.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)
@@ -125,9 +128,18 @@ GEM
     nio4r (2.7.4)
     nokogiri (1.18.10-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
+    pdf-reader (2.15.0)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     pg (1.6.2-aarch64-linux)
+    pg (1.6.2-arm64-darwin)
     pg (1.6.2-x86_64-linux)
     pgvector (0.3.2)
     pp (0.6.3)
@@ -188,11 +200,14 @@ GEM
       tsort
     reline (0.6.2)
       io-console (~> 0.5)
+    ruby-rc4 (0.1.5)
     securerandom (0.4.1)
     stringio (3.1.7)
     thor (1.4.0)
     timeout (0.4.3)
     tsort (0.2.0)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (1.0.4)
@@ -205,12 +220,14 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
   debug
   dotenv-rails
   neighbor
+  pdf-reader (~> 2.12)
   pg (~> 1.1)
   pgvector (~> 0.3)
   propshaft

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker compose exec ollama ollama pull gemma3:4b
 ## 文書のimport方法
 
 ```
-# ingest/の全ファイルを取り込み（.mdもしくは.txtファイル）
+# ingest/の全ファイルを取り込み（.mdもしくは.txt,.pdfファイル）
 docker-compose exec web bundle exec rake rag:ingest
 
 # 取り込まれた文書を確認


### PR DESCRIPTION
## チケットリンク
- close #1 

## 作業内容
pdf形式取り込み機能追加

## 動作確認
ingest/docs/にpdfファイルを置き、取り込みを実行
```
docker compose exec web bundle exec rake rag:ingest
```

pdfのサイズが大きいとコンテキストが長すぎて失敗する可能性がある