### PR TITLE
埋め込みモデルを日本語に特化したものに変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+/embedder/__pycache__/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,9 +125,12 @@ GEM
     nio4r (2.7.4)
     nokogiri (1.18.10-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     pg (1.6.2-aarch64-linux)
+    pg (1.6.2-arm64-darwin)
     pg (1.6.2-x86_64-linux)
     pgvector (0.3.2)
     pp (0.6.3)
@@ -205,6 +208,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -82,17 +82,11 @@ class Document < ApplicationRecord
     require 'net/http'
     require 'json'
 
-    # Docker環境では環境変数からOllama URLを取得
-    ollama_base_url = ENV['OLLAMA_BASE_URL'] || 'http://localhost:11434'
-    ollama_model = ENV['OLLAMA_EMBED_MODEL'] || 'nomic-embed-text'
-
-    # Ollama APIのエンドポイント
-    uri = URI("#{ollama_base_url}/api/embeddings")
+    uri = URI(ENV['EMBED_API_URL'] || 'http://localhost:8000/embed')
 
     # リクエストボディ
     request_body = {
-      model: ollama_model,
-      prompt: text
+      text: text
     }.to_json
 
     # HTTPリクエストを送信

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - RAILS_ENV=development
       - DATABASE_URL=postgres://postgres:postgres@db:5432/rag_dev
+      - EMBED_API_URL=http://embedder:8000/embed
       - OLLAMA_BASE_URL=http://ollama:11434
       - OLLAMA_EMBED_MODEL=nomic-embed-text   # 768次元
       - OLLAMA_GEN_MODEL=gemma2:2b # より軽量で高速なモデル
@@ -15,6 +16,7 @@ services:
     depends_on:
       - db
       - ollama
+      - embedder
 
   db:
     image: pgvector/pgvector:pg16   # pgvector入りのPostgres 16
@@ -37,6 +39,14 @@ services:
       - "11434:11434"
     volumes:
       - ollama:/root/.ollama
+
+  embedder:
+    build: ./embedder
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./embedder:/app
+
 volumes:
   ollama: {}
   db-data: {}

--- a/embedder/Dockerfile
+++ b/embedder/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# 必要ライブラリ
+RUN pip install --no-cache-dir \
+    torch sentence-transformers fastapi uvicorn[standard] numpy sentencepiece protobuf
+
+# GLuCoSE-base-ja は初回起動時に自動ダウンロードされる
+COPY . /app
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/embedder/main.py
+++ b/embedder/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from sentence_transformers import SentenceTransformer
+import numpy as np
+
+app = FastAPI()
+model = SentenceTransformer("pkshatech/GLuCoSE-base-ja")
+
+class EmbedRequest(BaseModel):
+    text: str
+
+@app.post("/embed")
+def embed(req: EmbedRequest):
+    vector = model.encode(req.text)
+    return {"embedding": vector.tolist()}

--- a/lib/tasks/rag.rake
+++ b/lib/tasks/rag.rake
@@ -190,46 +190,8 @@ namespace :rag do
   private
 
   def generate_embedding(text)
-    # Docker環境では環境変数からOllama URLを取得
-    ollama_base_url = ENV['OLLAMA_BASE_URL'] || 'http://localhost:11434'
-    ollama_model = ENV['OLLAMA_EMBED_MODEL'] || 'nomic-embed-text'
-
-    # Ollama APIのエンドポイント
-    uri = URI("#{ollama_base_url}/api/embeddings")
-
-    # リクエストボディ
-    request_body = {
-      model: ollama_model,
-      prompt: text
-    }.to_json
-
-    # HTTPリクエストを送信
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.read_timeout = 60 # タイムアウトを60秒に設定
-
-    request = Net::HTTP::Post.new(uri)
-    request['Content-Type'] = 'application/json'
-    request.body = request_body
-
-    begin
-      response = http.request(request)
-
-      if response.code == '200'
-        result = JSON.parse(response.body)
-        return result['embedding']
-      else
-        puts "Error from Ollama API: #{response.code} #{response.message}"
-        puts response.body
-        return nil
-      end
-    rescue => e
-      puts "Error connecting to Ollama: #{e.message}"
-      puts "Ollama URL: #{ollama_base_url}"
-      puts "Make sure:"
-      puts "1. Ollama service is running (docker-compose up ollama)"
-      puts "2. #{ollama_model} model is installed"
-      puts "3. Network connectivity between containers is working"
-      return nil
-    end
+    uri = URI(ENV['EMBED_API_URL'])
+    res = Net::HTTP.post(uri, { text: text }.to_json, "Content-Type" => "application/json")
+    JSON.parse(res.body)["embedding"]
   end
 end


### PR DESCRIPTION
## チケットリンク
- close #2 

## 作業内容
- 埋め込みモデルを日本語特化のGLuCoSE-base-jaに変更
- docker-composeにembedderサービスを追加
(GLuCoSE-base-jaがpythonで動くため、別途立ててRailsからAPIでアクセスする)

## 確認事項
検索精度の向上を確認(例：就業規則の「残業の定義」)
